### PR TITLE
fixed minor bug in which caused node to crash when adding to context

### DIFF
--- a/extensions/aws/src/nodes/s3PutObject.ts
+++ b/extensions/aws/src/nodes/s3PutObject.ts
@@ -235,7 +235,7 @@ export const s3PutObjectNode = createNodeDescriptor({
 		if (storeLocation === "input" && inputKey) {
 			cognigy.input[inputKey] = result;
 		} else if (storeLocation === "context" && contextKey) {
-			cognigy.api.setContext(contextKey, result);
+			cognigy.api.addToContext(contextKey, result, 'simple');
 		}
 	}
 });


### PR DESCRIPTION
Changed the add to context function to cognigy.api.addToContext as the node was crashing in my environment with the other command. This extension in general might need an overhaul. 