### PR TITLE
Bug/vier cognitive voice gateway

### DIFF
--- a/extensions/vier-cognitive-voice-gateway/package-lock.json
+++ b/extensions/vier-cognitive-voice-gateway/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vier-voice",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,9 +28,9 @@
       }
     },
     "@cognigy/extension-tools": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@cognigy/extension-tools/-/extension-tools-0.12.0.tgz",
-      "integrity": "sha512-LgnrPYuJX/e6Uo/pe7knkAfZ5tBOd0+Q/MV9gpao1WmOGU12lMdJkOQvYUc7rGta3jA0KO0wnnWJz/4W69XhXQ=="
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@cognigy/extension-tools/-/extension-tools-0.14.0.tgz",
+      "integrity": "sha512-DDP46/qqZKSB3+p+IjaA9aCOKcfSqaa3uGwCaTQV7rM375BS6baUK95/ELY3qX7sx0XbghH0Smq/5UtAKd17GA=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -287,9 +287,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/extensions/vier-cognitive-voice-gateway/package.json
+++ b/extensions/vier-cognitive-voice-gateway/package.json
@@ -1,14 +1,14 @@
 {
   "name": "vier-voice",
   "description": "Enable phone bots with VIER Cognitive Voice Gateway",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "build/module.js",
   "author": "Cognigy GmbH",
   "license": "MIT",
   "dependencies": {
-    "@cognigy/extension-tools": "^0.12.0",
+    "@cognigy/extension-tools": "^0.14.0",
     "tslint": "^6.1.3",
-    "typescript": "^4.3.5"
+    "typescript": "^4.5.2"
   },
   "scripts": {
     "zip": "tar cfz vier_voice.tar.gz build/* icon.png README.md package.json package-lock.json",

--- a/extensions/vier-cognitive-voice-gateway/src/nodes/speak.ts
+++ b/extensions/vier-cognitive-voice-gateway/src/nodes/speak.ts
@@ -244,16 +244,14 @@ export const speakNode = createNodeDescriptor({
     },
   ],
   function: async ({ cognigy, config }: ISpeakNodeParams) => {
-    const xmlRegex = /<.*>.*<\/.*>/gm;
-    const hasSsmlTags = (msg: string) => xmlRegex.test(msg);
-
-    if (hasSsmlTags(config.text)) {
-      if (!config.text.startsWith('<speak>') || !config.text.endsWith('</speak>'))
+    if (!config.text.startsWith('<speak>') || !config.text.endsWith('</speak>')) {
       cognigy.api.say(`<speak>${config.text}</speak>`, {
         interpretAs: 'SSML'
       });
     } else {
-      cognigy.api.say(config.text);
+      cognigy.api.say(config.text, {
+        interpretAs: 'SSML'
+      });
     }
   },
 });


### PR DESCRIPTION
Fixed a bug where we tested the entered text for opening and closing tags which did skip self-closed tags. Fixed this by always wrapping the text in `<speak>` as the node explicitly mentions the use of SSML in its name.