### PR TITLE
Making extension names consistent with marketplace

### DIFF
--- a/extensions/aws/src/module.ts
+++ b/extensions/aws/src/module.ts
@@ -20,6 +20,6 @@ export default createExtension({
 	],
 
 	options: {
-		label: "AWS"
+		label: "Amazon Web Services"
 	}
 });

--- a/extensions/google-translator/src/module.ts
+++ b/extensions/google-translator/src/module.ts
@@ -16,6 +16,6 @@ export default createExtension({
 	],
 
 	options: {
-		label: "Google Translate"
+		label: "Google Translator"
 	}
 });

--- a/extensions/parcellab/src/module.ts
+++ b/extensions/parcellab/src/module.ts
@@ -13,6 +13,6 @@ export default createExtension({
     ],
 
     options: {
-        label: "ParcelLab"
+        label: "Parcel Lab"
     }
 });

--- a/extensions/uipath/src/module.ts
+++ b/extensions/uipath/src/module.ts
@@ -40,6 +40,6 @@ export default createExtension({
 	],
 
 	options: {
-		label: "UiPath"
+		label: "UiPath Orchestrator"
 	}
 });


### PR DESCRIPTION
This PR fixes the name of some custom modules, so that they remain consistent with the names from Marketplace.