### PR TITLE
crypto: add HMAC support for secret signed hash authentication

### DIFF
--- a/extensions/crypto/package-lock.json
+++ b/extensions/crypto/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crypto",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crypto",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.13.0",

--- a/extensions/crypto/package.json
+++ b/extensions/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crypto",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Crypto",
   "main": "build/module.js",
   "scripts": {

--- a/extensions/crypto/src/module.ts
+++ b/extensions/crypto/src/module.ts
@@ -4,13 +4,15 @@ import * as crypto from 'crypto';
 import {createHashNode} from "./nodes/createHash";
 import {decryptNode} from "./nodes/decrypt";
 import {encryptNode} from "./nodes/encrypt";
+import {hmacNode} from "./nodes/hmac";
 
 
 export default createExtension({
 	nodes: [
 		createHashNode,
 		decryptNode,
-		encryptNode
+		encryptNode,
+		hmacNode
 	],
 
 	options: {

--- a/extensions/crypto/src/nodes/decrypt.ts
+++ b/extensions/crypto/src/nodes/decrypt.ts
@@ -564,7 +564,6 @@ export const decryptNode = createNodeDescriptor({
 			// Prepare key and iv with correct lengths
 			const keyBuffer = Buffer.from(key);
 			const ivBuffer = Buffer.from(iv, 'utf8');
-			
 			const decipher = crypto.createDecipheriv(algorithm, keyBuffer, ivBuffer);
 			let decrypted = decipher.update(text, 'hex', 'utf8');
 			decrypted += decipher.final('utf8');
@@ -584,7 +583,6 @@ export const decryptNode = createNodeDescriptor({
 				// @ts-ignore
 				api.addToInput(inputKey, error.message);
 			}
-
 		}
 	}
 });

--- a/extensions/crypto/src/nodes/encrypt.ts
+++ b/extensions/crypto/src/nodes/encrypt.ts
@@ -567,15 +567,14 @@ export const encryptNode = createNodeDescriptor({
 		try {
 			// Prepare key with correct length
 			const keyBuffer = Buffer.from(key);
-			
 			const ivBuffer = Buffer.from(iv, 'utf8');
 
 			const cipher = crypto.createCipheriv(algorithm, keyBuffer, ivBuffer);
 			let crypted = cipher.update(text, 'utf8', 'hex');
 			crypted += cipher.final('hex');
-			
+
 			// Include the IV with the result for decryption
-			result = { 
+			result = {
 				"result": crypted,
 				"iv": ivBuffer.toString('utf8')
 			};

--- a/extensions/crypto/src/nodes/hmac.ts
+++ b/extensions/crypto/src/nodes/hmac.ts
@@ -1,0 +1,160 @@
+import { createNodeDescriptor, INodeFunctionBaseParams } from "@cognigy/extension-tools";
+import * as crypto from 'crypto';
+
+export interface IHmac extends INodeFunctionBaseParams {
+	config: {
+		algorithm: string;
+		message: string;
+		secret: string;
+		storeHmac: string;
+		inputKey: string;
+		contextKey: string;
+	};
+}
+
+export const hmacNode = createNodeDescriptor({
+	type: "hmac",
+	defaultLabel: "HMAC",
+	fields: [
+		{
+			key: "algorithm",
+			label: "The HMAC algorithm to use",
+			type: "select",
+			defaultValue: "sha256",
+			params: {
+				required: true,
+				options: [
+					{
+						label: "SHA256",
+						value: "sha256"
+					},
+					{
+						label: "SHA1",
+						value: "sha1"
+					},
+					{
+						label: "SHA384",
+						value: "sha384"
+					},
+					{
+						label: "SHA512",
+						value: "sha512"
+					},
+					{
+						label: "MD5",
+						value: "md5"
+					}
+				]
+			}
+		},
+		{
+			key: "message",
+			label: "The message to authenticate",
+			type: "cognigyText",
+			defaultValue: "{{input.text}}",
+			params: {
+				required: true
+			}
+		},
+		{
+			key: "secret",
+			label: "The secret key",
+			type: "cognigyText",
+			defaultValue: "",
+			params: {
+				required: true
+			}
+		},
+		{
+			key: "storeHmac",
+			type: "select",
+			label: "Where to store the result",
+			params: {
+				options: [
+					{
+						label: "Input",
+						value: "input"
+					},
+					{
+						label: "Context",
+						value: "context"
+					}
+				],
+				required: true
+			},
+			defaultValue: "context"
+		},
+		{
+			key: "inputKey",
+			type: "cognigyText",
+			label: "Input Key to store Result",
+			defaultValue: "hmac",
+			condition: {
+				key: "storeHmac",
+				value: "input"
+			}
+		},
+		{
+			key: "contextKey",
+			type: "cognigyText",
+			label: "Context Key to store Result",
+			defaultValue: "hmac",
+			condition: {
+				key: "storeHmac",
+				value: "context"
+			}
+		}
+	],
+	sections: [
+		{
+			key: "storageOption",
+			label: "Storage Option",
+			defaultCollapsed: true,
+			fields: [
+				"storeHmac",
+				"inputKey",
+				"contextKey",
+			]
+		}
+	],
+	form: [
+		{ type: "field", key: "algorithm" },
+		{ type: "field", key: "message" },
+		{ type: "field", key: "secret" },
+		{ type: "section", key: "storageOption" },
+	],
+	appearance: {
+		color: "#0f2b46"
+	},
+
+	function: async ({ cognigy, config }: IHmac) => {
+		const { api } = cognigy;
+		const { algorithm, message, secret, storeHmac, inputKey, contextKey } = config;
+		let result = {};
+
+		if (!message) result = Promise.reject("No message defined.");
+		if (!secret) result = Promise.reject("No secret defined.");
+		if (!algorithm) result = Promise.reject("No algorithm defined.");
+
+		try {
+			const hmac = crypto.createHmac(algorithm, secret);
+			hmac.update(message);
+			const hash = hmac.digest('hex');
+			result = { "result": hash };
+
+			if (storeHmac === "context") {
+				api.addToContext(contextKey, result, "simple");
+			} else {
+				// @ts-ignore
+				api.addToInput(inputKey, result);
+			}
+		} catch (error) {
+			if (storeHmac === "context") {
+				api.addToContext(contextKey, error.message, "simple");
+			} else {
+				// @ts-ignore
+				api.addToInput(inputKey, error.message);
+			}
+		}
+	}
+});


### PR DESCRIPTION
  - Add new HMAC node to enable cryptographically secure message authentication using secret keys
  - Support multiple HMAC algorithms (SHA256, SHA1, SHA384, SHA512, MD5) for flexible security requirements
  - Provide configurable message input and secret key parameters with storage options (input/context)
  - Integrate HMAC functionality into crypto extension module alongside existing encrypt/decrypt operations
  - Clean up formatting in encrypt/decrypt nodes for consistency
  - Bump version to 5.0.1 to reflect new HMAC authentication capabilities