### PR TITLE
Set Knowledge Connector sections after Extension Node sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Cognigy Extensions
 
-## Knowledge Connectors
-In [Cognigy.AI](https://cognigy.com/product/), [Knowledge Stores](https://docs.cognigy.com/ai/empower/knowledge-ai/knowledge-store/?h=knowled) are used to store information that your AI Agents can access as context through [Knowledge AI](https://docs.cognigy.com/ai/empower/knowledge-ai/overview). Extensions allow you to build JavaScript modules and expose them as [Knowledge Connectors](https://docs.cognigy.com/docs/knowledge-connector) within Cognigy.AI. Knowledge Connectors can integrate with any third-party system and fetch data or files from external knowledge bases such as Confluence, SharePoint, and more. There are no restrictions on which Node.js modules ([NPM](https://www.npmjs.com/)) or functionality you can use.
-
 ## Nodes
 In [Cognigy.AI](https://cognigy.com/product/), you can use [Flows](https://docs.cognigy.com/ai/build/flows/overview/) to build custom AI Agents and you might need to integrate a third-party system to store or retrieve data. Extensions let you build JavaScript modules and expose them as [Nodes](https://docs.cognigy.com/ai/build/node-reference/overview/) within Cognigy.AI. There are no restrictions on node modules ([NPM](https://www.npmjs.com/)) or functionality.
+
+## Knowledge Connectors
+In [Cognigy.AI](https://cognigy.com/product/), [Knowledge Stores](https://docs.cognigy.com/ai/empower/knowledge-ai/knowledge-store/) are used to store information that your AI Agents can access as context through [Knowledge AI](https://docs.cognigy.com/ai/agents/develop/knowledge-ai/overview/). Extensions allow you to build JavaScript modules and expose them as [Knowledge Connectors](https://docs.cognigy.com/ai/for-devlopers/extensions#knowledge-connectors) within Cognigy.AI. Knowledge Connectors can integrate with any third-party system and fetch data or files from external knowledge bases such as Confluence, SharePoint, and more. There are no restrictions on which Node.js modules ([NPM](https://www.npmjs.com/)) or functionality you can use.
 
 ### NPM: @cognigy/extension-tools
 

--- a/extensions/cognigy/README.md
+++ b/extensions/cognigy/README.md
@@ -1,50 +1,15 @@
 
 # Cognigy.AI
 
-This Extension provides Nodes to extend Cognigy.AI core features and Knowledge Connectors to integrate external data sources into Cognigy.AI.
+This Extension provides:
+
+- Nodes to extend Cognigy.AI core features
+- Knowledge Connectors to integrate external data sources into Cognigy.AI. The Knowledge Connectors create Knowledge Sources by using web APIs or extracting content from publicly available web pages.
 
 ## Table of Contents
-- [Cognigy.AI Knowledge Connectors](#knowledge-connectors)
+
 - [Cognigy.AI Nodes](#nodes)
-
----
-
-# Cognigy.AI Extension
-
-This Extension provides Knowledge Connectors that integrate external data sources into Cognigy.AI. The provided Knowledge Connectors create Knowledge Sources by using web APIs or extracting content from publicly available web pages.
-
-## Knowledge Connectors
-
-### Chuck Norris Jokes
-
-The Chuck Norris Jokes Knowledge Connector fetches random Chuck Norris Jokes using a web API and creates a Knowledge Source with Knowledge Chunks containing the fetched jokes.
-
-The following table shows the fields to configure when using this Knowledge Connector.
-
-| Field                      | Description                                                                                                                                                                                                                                                |
-|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Source name prefix         | Sets a prefix to be appended to Knowledge Source's name. For example, if you enter `Chuck Norris Jokes`, the Knowledge Source created is named `Chuck Norris Jokes - <category>`.                                                                          |
-| Categories to fetch        | Sets the categories of jokes to fetch. You can find the available categories at [chucknorris.io](https://api.chucknorris.io/), in the **Usage** section, or at [https://api.chucknorris.io/jokes/categories](https://api.chucknorris.io/jokes/categories). |
-| Number of jokes per source | Sets a number of jokes per category.                                                                                                                                                                                                                       |
-| Source Tags                | Sets the Source Tags that you want to add to Knowledge Source. Source Tags can be used to filter the search scope when using a Search Extract Output Node.                                                                                                 |
-
-### Web Page
-
-The Web Page Knowledge Connector lets you extract content from publicly available static web pages. This Knowledge Connector creates a Knowledge Source and Knowledge Chunks based on the web page content.
-
-#### Chunking
-
-The Knowledge Connector divides the web page content automatically into Knowledge Chunks based on semantic structures. If a semantic structure exceeds the 2000 characters, it's split into smaller Knowledge Chunks based on character count.
-
-The following table shows the fields to configure when using this Knowledge Connector.
-
-| Field              | Description                                                                                                                                                             |
-|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Source name prefix | Sets an optional prefix to be appended to the Knowledge Source's name. For example, if you enter `Wiki Page`, the Knowledge Source created is named `Wiki Page - <cleaned web page URL>`. |
-| Web page URL       | Sets the URL of the publicly available web page from which the content is extracted.                                                                                    |
-| Source Tags        | Sets the Source Tags that you want to add to the  Knowledge Source. Source Tags can be used to filter the search scope when using a Search Extract Output Node.         |
-
-**Note:** The Knowledge Connector uses the following MIT-licensed libraries: [`html-to-text`](https://www.npmjs.com/package/html-to-text), [`langchain`](https://www.npmjs.com/package/langchain), [`jsdom`](https://www.npmjs.com/package/jsdom)
+- [Cognigy.AI Knowledge Connectors](#knowledge-connectors)
 
 ## Nodes
 
@@ -108,3 +73,36 @@ The following is an example of a stored response:
 **Important**
 
 The maximum delta value is between 0 and 1. The smaller the delta value, the more refined the disambiguation results are.
+
+## Knowledge Connectors
+
+### Chuck Norris Jokes
+
+The Chuck Norris Jokes Knowledge Connector fetches random Chuck Norris Jokes using a web API and creates a Knowledge Source with Knowledge Chunks containing the fetched jokes.
+
+The following table shows the fields to configure when using this Knowledge Connector.
+
+| Field                      | Description                                                                                                                                                                                                                                                |
+|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Source name prefix         | Sets a prefix to be appended to Knowledge Source's name. For example, if you enter `Chuck Norris Jokes`, the Knowledge Source created is named `Chuck Norris Jokes - <category>`.                                                                          |
+| Categories to fetch        | Sets the categories of jokes to fetch. You can find the available categories at [chucknorris.io](https://api.chucknorris.io/), in the **Usage** section, or at [https://api.chucknorris.io/jokes/categories](https://api.chucknorris.io/jokes/categories). |
+| Number of jokes per source | Sets a number of jokes per category.                                                                                                                                                                                                                       |
+| Source Tags                | Sets the Source Tags that you want to add to Knowledge Source. Source Tags can be used to filter the search scope when using a Search Extract Output Node.                                                                                                 |
+
+### Web Page
+
+The Web Page Knowledge Connector lets you extract content from publicly available static web pages. This Knowledge Connector creates a Knowledge Source and Knowledge Chunks based on the web page content.
+
+#### Chunking
+
+The Knowledge Connector divides the web page content automatically into Knowledge Chunks based on semantic structures. If a semantic structure exceeds the 2000 characters, it's split into smaller Knowledge Chunks based on character count.
+
+The following table shows the fields to configure when using this Knowledge Connector.
+
+| Field              | Description                                                                                                                                                             |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Source name prefix | Sets an optional prefix to be appended to the Knowledge Source's name. For example, if you enter `Wiki Page`, the Knowledge Source created is named `Wiki Page - <cleaned web page URL>`. |
+| Web page URL       | Sets the URL of the publicly available web page from which the content is extracted.                                                                                    |
+| Source Tags        | Sets the Source Tags that you want to add to the  Knowledge Source. Source Tags can be used to filter the search scope when using a Search Extract Output Node.         |
+
+**Note:** The Knowledge Connector uses the following MIT-licensed libraries: [`html-to-text`](https://www.npmjs.com/package/html-to-text), [`langchain`](https://www.npmjs.com/package/langchain), [`jsdom`](https://www.npmjs.com/package/jsdom)

--- a/extensions/confluence/README.md
+++ b/extensions/confluence/README.md
@@ -1,56 +1,16 @@
-﻿# Atlassian Confluence
+﻿# Atlassian Confluence Extension
 
-Integrates Cognigy.AI with Confluence (https://www.atlassian.com/software/confluence)
+Integrates Cognigy.AI with Confluence (https://www.atlassian.com/software/confluence).
 
-Confluence is a popular collaboration tool that allows teams to work together by writing knowledge articles, how-to's, and other guides. By integrating Confluence with Cognigy.AI, you can create Cognigy AI Agents that can search through your Confluence knowledge base and provide users with context-aware responses. The Confluence Extension provides [Knowledge Connectors](#confluence-knowledge-connectors) and [Flow Nodes](#confluence-flow-nodes).
+Confluence is a popular collaboration tool that allows teams to work together by writing knowledge articles, how-to's, and other guides. By integrating Confluence with Cognigy.AI, you can create Cognigy AI Agents that can search through your Confluence knowledge base and provide users with context-aware responses. The Confluence Extension provides [Extension Nodes](#confluence-flow-nodes) and [Knowledge Connectors](#confluence-knowledge-connectors).
 
 ## Table of Contents
+
+- [Confluence Extension Nodes](#confluence-flow-nodes)
 - [Confluence Knowledge Connectors](#confluence-knowledge-connectors)
-- [Confluence Flow Nodes](#confluence-flow-nodes)
 - [Confluence Connection](#confluence-connection)
 
----
-## Confluence Knowledge Connectors
-
-The Confluence Knowledge Connector allows you to connect to Confluence and retrieve data from its pages or folders. This Knowledge Connector adds Knowledge Sources based on the pages retrieved from Confluence. The Extension transforms Confluence's HTML output into structured Markdown. This conversion process supports custom transformation rules and plugins, enabling precise handling of Confluence-specific elements such as macros, panels, and structured content blocks.
-
-### Heading-Based Chunking
-
-Content is automatically divided into Knowledge Chunks based on the heading hierarchy in Confluence. The chunking behavior is the following:
-- **H1, H2**: Start new Knowledge Chunks
-- **H3, H4, H5, H6**: Include in the current Knowledge Chunk
-
-If a Knowledge Chunk exceeds the default max length of 2000 characters, it will be further divided into smaller chunks.
-
-### Supported Confluence Content Types
-
-- Plain and formatted text
-- Tables
-- Bulleted and numbered lists
-- Panels (info, warning, error, success)
-- Expandable sections
-- Task lists
-- Alternative text of images
-
-### Fields
-
-**Connection:**
-Connection field as defined in [Connection](#confluence-connection)
-
-**Confluence URL:**
-URL of the Confluence page or folder to be extracted
-
-**Extract Descendants:**
-When enabled, extracts content from the specified page and all its descendant pages. When disabled, extracts only the specified page content. This setting applies only to individual page URLs. For folder URLs, all pages within the folder are always extracted.
-
-**Source Tags:**
-Sets the tags that you want to associate with each Knowledge Source
-
-**Note:** The connector uses the following MIT-licensed libraries: [`turndown`](https://www.npmjs.com/package/turndown), [`langchain`](https://www.npmjs.com/package/langchain)
-
----
-
-## Confluence Flow Nodes
+## Confluence Extension Nodes
 
 ### Node: Search
 
@@ -106,9 +66,46 @@ This Node returns all pages within a specific Confluence space. In order to get 
 
  **Please Note** : The response object gives back an array of results. If one or more results have been found, the relevant HTML is also returned. This can be used to render the output in the front-end webchat.
 
----
+## Confluence Knowledge Connectors
 
-# Confluence Connection
+The Confluence Knowledge Connector allows you to connect to Confluence and retrieve data from its pages or folders. This Knowledge Connector adds Knowledge Sources based on the pages retrieved from Confluence. The Extension transforms Confluence's HTML output into structured Markdown. This conversion process supports custom transformation rules and plugins, enabling precise handling of Confluence-specific elements such as macros, panels, and structured content blocks.
+
+### Heading-Based Chunking
+
+Content is automatically divided into Knowledge Chunks based on the heading hierarchy in Confluence. The chunking behavior is the following:
+- **H1, H2**: Start new Knowledge Chunks
+- **H3, H4, H5, H6**: Include in the current Knowledge Chunk
+
+If a Knowledge Chunk exceeds the default max length of 2000 characters, it will be further divided into smaller chunks.
+
+### Supported Confluence Content Types
+
+- Plain and formatted text
+- Tables
+- Bulleted and numbered lists
+- Panels (info, warning, error, success)
+- Expandable sections
+- Task lists
+- Alternative text of images
+
+### Fields
+
+**Connection:**
+Connection field as defined in [Connection](#confluence-connection)
+
+**Confluence URL:**
+URL of the Confluence page or folder to be extracted
+
+**Extract Descendants:**
+When enabled, extracts content from the specified page and all its descendant pages. When disabled, extracts only the specified page content. This setting applies only to individual page URLs. For folder URLs, all pages within the folder are always extracted.
+
+**Source Tags:**
+Sets the tags that you want to associate with each Knowledge Source
+
+**Note:** The connector uses the following MIT-licensed libraries: [`turndown`](https://www.npmjs.com/package/turndown), [`langchain`](https://www.npmjs.com/package/langchain)
+
+
+## Confluence Connection
 
 This module needs a CognigySecret to be defined and passed to the Extension Node and/or Knowledge Connector. A CognigySecret can be added to any Cognigy Project and allows for the encryption of sensitive data. The secret must have the following keys:
 - **domain:** The base URL of your Confluence application i.e, https://xyz.atlassian.net. This field is not required for the Knowledge Connectors

--- a/extensions/diffbot/README.md
+++ b/extensions/diffbot/README.md
@@ -1,25 +1,17 @@
 
 # Diffbot
 
-This Extension provides two basic Diffbot Knowledge Connectors allow integration between Cognigy.AI and Diffbot:
+This Extension provides two basic Diffbot Knowledge Connectors allow integration between Cognigy.AI and Diffbot extract structured data from web pages in JSON format with the following Knowledge Connectors:
 
-- One that crawls through web pages and creates Knowledge Sources with Knowledge Chunks.
-- Another that accepts web page URL and generates Knowledge Sources directly.
+- [Diffbot Crawler](#diffbot-crawler)
+- [Diffbot Webpage Connector](#diffbot-webpage-connector)
 
 ## Table of Contents
+
 - [Diffbot Extension](#diffbot-extension)
 - [Diffbot Crawler](#diffbot-crawler)
 - [Diffbot Webpage Connector](#diffbot-webpage-connector)
 - [Diffbot Connection](#diffbot-connection)
-
----
-
-# Diffbot Extension
-
-The Diffbot Extension lets you extract structured data from web pages in JSON format with the following Knowledge Extensions:
-
-- [Diffbot Crawler](#diffbot-crawler)
-- [Diffbot Webpage Connector](#diffbot-webpage-connector)
 
 ## Diffbot Crawler
 
@@ -33,7 +25,7 @@ The JSON content returned by Diffbot is flattened and processed using recursive 
 
 #### Basic Settings
 
-| Basic Settings   | Description                                                                                                                                                                                                                                                                 |
+| Setting          | Description                                                                                                                                                                                                                                                                 |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Connection       | The Connection module as defined in [Connection](#diffbot-connection).                                                                                                                                                                                                      |
 | Seed URLs        | URLs from which Diffbot starts crawling. Enter one URL per line or entry, for example, `https://www.cognigy.com/careers`.                                                                                                                                                   |
@@ -60,7 +52,7 @@ The JSON content returned by Diffbot is flattened and processed using recursive 
 
 #### Processing Limits
 
-| Processing Limits            | Description                                                                            |
+| Processing Limit             | Description                                                                            |
 |------------------------------|----------------------------------------------------------------------------------------|
 | Processing Patterns          | Limits the URLs to process to the value in this field.                                 |
 | URL Processing Regex         | Sets regex to filter matching URL patterns to process.                                 |


### PR DESCRIPTION
@falak-asad After aligning with Ana, we are going to put the knowledge connectors after the extension nodes.

I also changed the links that you said were not working to the new ones as they are going to be in mintlify. See: https://github.com/Cognigy/mintlify-docs/pull/128