### PR TITLE
Fix issue with diffbot where Synced source is displayed with/without …

### DIFF
--- a/extensions/confluence/package-lock.json
+++ b/extensions/confluence/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "confluence",
-    "version": "5.1.0-rc.1",
+    "version": "6.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "confluence",
-            "version": "5.1.0-rc.1",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
                 "@cognigy/extension-tools": "^0.17.0-rc4",

--- a/extensions/confluence/package.json
+++ b/extensions/confluence/package.json
@@ -1,7 +1,7 @@
 {
     "name": "confluence",
     "version": "6.0.0",
-    "description": "Integrates with the Atlassian's Confluence.",
+    "description": "Integrates with the Atlassian's Confluence (Only compatible with Cognigy version v.2025.5.0 and above).",
     "main": "build/module.js",
     "scripts": {
         "transpile": "tsc -p tsconfig.production.json",

--- a/extensions/confluence/package.json
+++ b/extensions/confluence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "confluence",
-    "version": "5.1.0-rc.1",
+    "version": "6.0.0",
     "description": "Integrates with the Atlassian's Confluence.",
     "main": "build/module.js",
     "scripts": {

--- a/extensions/confluence/src/knowledge-connectors/confluenceConnector.ts
+++ b/extensions/confluence/src/knowledge-connectors/confluenceConnector.ts
@@ -91,10 +91,12 @@ export const confluenceConnector = createKnowledgeConnector({
 
 		// Clean up superseded sources
 		for (const source of currentSources) {
-			if (updatedSources.has(source.externalIdentifier)) {
+			if (
+				updatedSources.has(source.externalIdentifier) ||
+				!source.externalIdentifier
+			) {
 				continue;
 			}
-
 			await api.deleteKnowledgeSource({
 				knowledgeSourceId: source.knowledgeSourceId,
 			});

--- a/extensions/diffbot/package-lock.json
+++ b/extensions/diffbot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diffbot",
-  "version": "1.1.0-rc.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diffbot",
-      "version": "1.1.0-rc.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.17.0-rc4",

--- a/extensions/diffbot/package.json
+++ b/extensions/diffbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diffbot",
-  "version": "1.1.0-rc.1",
+  "version": "2.0.0",
   "description": "Integrates with the Diffbot API",
   "main": "build/module.js",
   "scripts": {

--- a/extensions/diffbot/package.json
+++ b/extensions/diffbot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diffbot",
   "version": "2.0.0",
-  "description": "Integrates with the Diffbot API",
+  "description": "Integrates with the Diffbot API (Only compatible with Cognigy version v.2025.5.0 and above).",
   "main": "build/module.js",
   "scripts": {
     "transpile": "tsc -p tsconfig.production.json",

--- a/extensions/diffbot/src/knowledge-connectors/diffbotWebpageConnector.test.ts
+++ b/extensions/diffbot/src/knowledge-connectors/diffbotWebpageConnector.test.ts
@@ -100,7 +100,7 @@ describe("diffbotWebpageConnector", () => {
 				description: `Content from web page at ${url}`,
 				tags: [],
 				chunkCount: 1,
-				externalIdentifier: `0.article|3|abc123@${url}`,
+				externalIdentifier: url,
 			},
 		);
 		assert.ok(
@@ -170,7 +170,7 @@ describe("diffbotWebpageConnector", () => {
 				name: "First Article",
 				description: `Content from web page at ${url}`,
 				tags: ["web"],
-				externalIdentifier: `0.article|3|first@${url}`,
+				externalIdentifier: url,
 			},
 		);
 		assert.partialDeepStrictEqual(
@@ -179,7 +179,7 @@ describe("diffbotWebpageConnector", () => {
 				name: "Second Article",
 				description: `Content from web page at ${url}`,
 				tags: ["web"],
-				externalIdentifier: `1.article|3|second@${url}`,
+				externalIdentifier: url,
 			},
 		);
 
@@ -233,7 +233,7 @@ describe("diffbotWebpageConnector", () => {
 					name: "Test Article",
 					description: `Content from web page at ${url}`,
 					chunkCount: 1,
-					externalIdentifier: `0.article|3|abc123@${url}`,
+					externalIdentifier: url,
 					tags: [],
 					contentHashOrTimestamp: "previous-hash",
 				},
@@ -248,7 +248,7 @@ describe("diffbotWebpageConnector", () => {
 				description: `Content from web page at ${url}`,
 				tags: [],
 				chunkCount: 1,
-				externalIdentifier: `0.article|3|abc123@${url}`,
+				externalIdentifier: url,
 			},
 		);
 
@@ -278,7 +278,7 @@ describe("diffbotWebpageConnector", () => {
 					name: "Old Article",
 					description: "Content from web page at https://example.com/old",
 					chunkCount: 1,
-					externalIdentifier: "0.article|3|old@https://example.com/old",
+					externalIdentifier: "https://example.com/old",
 					tags: [],
 					contentHashOrTimestamp: "old-hash",
 				},
@@ -317,7 +317,7 @@ describe("diffbotWebpageConnector", () => {
 					name: "Test Article",
 					description: `Content from web page at ${url}`,
 					chunkCount: 1,
-					externalIdentifier: `0.article|3|abc123@${url}`,
+					externalIdentifier: url,
 					tags: [],
 					contentHashOrTimestamp: "hash",
 				},

--- a/extensions/diffbot/src/knowledge-connectors/diffbotWebpageConnector.ts
+++ b/extensions/diffbot/src/knowledge-connectors/diffbotWebpageConnector.ts
@@ -152,7 +152,10 @@ export const diffbotWebpageConnector = createKnowledgeConnector({
 
 		// Clean up superseded sources
 		for (const source of currentSources) {
-			if (updatedSources.has(source.externalIdentifier)) {
+			if (
+				updatedSources.has(source.externalIdentifier) ||
+				!source.externalIdentifier
+			) {
 				continue;
 			}
 

--- a/extensions/diffbot/src/knowledge-connectors/diffbotWebpageConnector.ts
+++ b/extensions/diffbot/src/knowledge-connectors/diffbotWebpageConnector.ts
@@ -111,7 +111,7 @@ export const diffbotWebpageConnector = createKnowledgeConnector({
 			// Create chunks
 			for (let i = 0; i < analyze.objects.length; i++) {
 				const sourceData = analyze.objects[i];
-				const externalIdentifier = `${i}.${sourceData.diffbotUri}@${url}`;
+				const externalIdentifier = url;
 				const chunkTitle = `title: ${sourceData.title}\ntype: ${sourceData.type}\n`;
 				const chunks = await jsonSplit(sourceData, chunkTitle, [
 					"html",


### PR DESCRIPTION

#Fixes
- AB#126857
- AB#126877

# Changelog Section

- [x] Cognigy.AI

# Changelog

- [x] Fix bug in diffbot knowledge connector

# Success criteria

- The sources are updated correctly by diffbot

# How to test

1. Create diffbot webpage source with this URL https://www.utctime.net
2. Run sync. and it should update the source without changing the source name
3. Upload the diffbot and confluence extension to trial, and create a store->manual source. Run the extension and it should not delete the manual sources

[confluence.tar.gz](https://github.com/user-attachments/files/25709362/confluence.tar.gz)
[diffbot.tar.gz](https://github.com/user-attachments/files/25709365/diffbot.tar.gz)


# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [X] No security implications

# Additional considerations
- [ ] This PR impacts NLU
- [ ] This PR might have performance implications
- [ ] This PR changes an existing data model (and might affect existing legacy data)
  - Examples: adding, renaming, removing a field or changing the format or constraints of a field
- [ ] This PR might affect indexing 
  - Examples: adding a new param for model query from DB without creating a new index for this model

# Documentation Considerations

No additional documentation required.
