### PR TITLE
AB#139412 - Point diffbot registry entry to 2.0.1 release

### DIFF
--- a/metadata/extensions.json
+++ b/metadata/extensions.json
@@ -396,8 +396,8 @@
     {
       "name": "diffbot",
       "label": "Diffbot",
-      "version": "1.0.1",
-      "downloadUrl": "https://github.com/Cognigy/Extensions/releases/download/diffbot101/diffbot.tar.gz",
+      "version": "2.0.1",
+      "downloadUrl": "https://github.com/Cognigy/Extensions/releases/download/diffbot201/diffbot-2.0.1.tar.gz",
       "infoUrl": "https://github.com/Cognigy/Extensions/tree/master/extensions/diffbot",
       "description": "Integrates with the Diffbot API",
       "longDescription": "Diffbot provides a powerful API for crawling and importing the content of websites into your Knowledge Base.",


### PR DESCRIPTION
## Summary

Updates the `diffbot` entry in `metadata/extensions.json` to point at the **2.0.1** security release.

| Field | Before | After |
|---|---|---|
| `version` | `1.0.1` | `2.0.1` |
| `downloadUrl` | `.../diffbot101/diffbot.tar.gz` | `.../diffbot201/diffbot-2.0.1.tar.gz` |

The 2.0.1 release remediates all HIGH-severity Snyk findings (langsmith, yaml, ws, form-data) landed in #898. This also catches up the metadata entry, which was still at `1.0.1` — the 2.0.0 release did not update this file.

## ⚠️ Merge order

Do **not** merge until the `diffbot201` GitHub release exists (asset `diffbot-2.0.1.tar.gz` uploaded), otherwise `downloadUrl` will 404. Recommended: create the release first, then merge.

## How to test

1. After the `diffbot201` release is published, confirm the `downloadUrl` resolves (HTTP 200).
2. `metadata/extensions.json` remains valid JSON.