### PR TITLE
AB#146238 fix: address security vulnerabilities

### DIFF
--- a/extensions/chuck-norris-jokes/package-lock.json
+++ b/extensions/chuck-norris-jokes/package-lock.json
@@ -946,9 +946,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/extensions/diffbot/package-lock.json
+++ b/extensions/diffbot/package-lock.json
@@ -857,9 +857,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## Summary
Bumps `js-yaml` 4.1.1 → 4.3.0 in the `diffbot` and `chuck-norris-jokes` extensions to fix a Snyk-flagged CVE (high severity). 4.3.0 is a security-only backport (`maxTotalMergeKeys`); confirmed the "breaking change" label Snyk sometimes attaches to this bump is a false positive (matches the 4.0.0 `safeLoad`-removal changelog entry, not anything in the 4.1→4.3 range).

## Security
No security implications beyond the fix itself — transitive dev/runtime dependency patch, no API surface change.

## How to test
1. `npm run build` in `extensions/diffbot` and `extensions/chuck-norris-jokes` (transpile + lint + test + zip)
2. `snyk test` in both extensions reports the js-yaml CVE cleared

## Verification
- diffbot: 6/6 tests pass, build clean, snyk clean for js-yaml
- chuck-norris-jokes: build clean, snyk clean for js-yaml
- Remaining Snyk findings (langchain major, ws minor) are pre-existing and out of scope for this fix
