### PR TITLE
CGY-33713: Fix extension names not matching for 8x8 and Microsoft Power Automate

### DIFF
--- a/metadata/extensions.json
+++ b/metadata/extensions.json
@@ -1585,7 +1585,7 @@
       ]
     },
     {
-      "name": "microsoft-powerautomate",
+      "name": "microsoft-power-automate",
       "label": "Microsoft Power Automate",
       "version": "4.0.0",
       "description": "Trigger automation processes within a virtual agent conversation",
@@ -1848,7 +1848,7 @@
       ]
     },
     {
-      "name": "8x8",
+      "name": "8x8-cognigy-extension",
       "label": "8x8",
       "version": "5.3.0",
       "downloadUrl": "https://github.com/Cognigy/Extensions/releases/download/8x8530/8x8.tar.gz",


### PR DESCRIPTION
2 extensions do not having matching names to what is set in their respective `package.json`: 8x8 and Microsoft Power Automate. This results in non-matching installation both on legacy Extensions page and also in the new Marketplace MFE.
